### PR TITLE
Fixed max value selection

### DIFF
--- a/js/bootstrap-slider.js
+++ b/js/bootstrap-slider.js
@@ -1368,11 +1368,16 @@
 				var sliderOffset = this._state.offset[this.stylePos];
 				var distanceToSlide = eventPosition - sliderOffset;
 				// Calculate what percent of the length the slider handle has slid
-				var percentage = (distanceToSlide / this._state.size) * 100;
-				percentage = Math.round(percentage / this._state.percentage[2]) * this._state.percentage[2];
-				if (this.options.reversed) {
-					percentage = 100 - percentage;
-				}
+				var selectedPercentage = (distanceToSlide / this._state.size) * 100;
+		                var nearestPercentage = Math.round(selectedPercentage / this._state.percentage[2]) * this._state.percentage[2];
+		
+		                // if the maximum is not equal to a step value, select max when user selects the max value.
+		                var percentage = 100 - selectedPercentage < Math.abs(nearestPercentage - selectedPercentage) ?
+		                    100 : nearestPercentage;
+		
+		                if (this.options.reversed) {
+		                    percentage = 100 - percentage;
+		                }
 
 				// Make sure the percent is within the bounds of the slider.
 				// 0% corresponds to the 'min' value of the slide
@@ -1490,6 +1495,11 @@
                 }
 			},
 			_toValue: function(percentage) {
+				if (percentage === 100) {
+		                    return this.options.max;
+		                } else if (percentage === 0) {
+		                    return this.options.min;
+		                }
 				return this.options.scale.toValue.apply(this, [percentage]);
 			},
 			_toPercentage: function(value) {


### PR DESCRIPTION
When we have a slider with a custom step value, if the max slider value is not equal to a multiple of the step value, slider fails to select the max value.
For example, having the following settings prevents the user to select the maximum value:
{
    min:0,
    max: 4200,
    value:1000,
    step:1000
 }

Here is the example : http://embed.plnkr.co/D3GJQn/preview

if bootstrap-slider-fixed.js is referenced it will work.